### PR TITLE
workaround bug in marketplace API around plugin compatibility

### DIFF
--- a/classes/MatomoMarketplaceApi.php
+++ b/classes/MatomoMarketplaceApi.php
@@ -96,7 +96,12 @@ class MatomoMarketplaceApi {
 	}
 
 	public function get_plugins() {
-		$result = $this->request_api( 'wordpress/plugins', array() );
+		$result = $this->request_api(
+			'wordpress/plugins',
+			// workaround bug in marketplace API that returns incompatible plugins
+			// if prefer_stable=1 is not set
+			[ 'prefer_stable' => '1' ]
+		);
 		if ( ! empty( $result['plugins'] ) ) {
 			return $result['plugins'];
 		}


### PR DESCRIPTION
### Description:

The bug causes the plugin listing API method to return plugins that are incompatible with the requested matomo version, unless `prefer_stable=1` is sent in the request.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
