### PR TITLE
remove api endpoint path before constructing plugin download URL

### DIFF
--- a/classes/MatomoMarketplaceApi.php
+++ b/classes/MatomoMarketplaceApi.php
@@ -126,8 +126,10 @@ class MatomoMarketplaceApi {
 
 		$currency = $this->get_currency_based_on_timezone();
 
+		$host = 'https://' . parse_url( $this->endpoint, PHP_URL_HOST ) . '/';
+
 		$result = array_map(
-			function ( $plugin ) use ( $currency ) {
+			function ( $plugin ) use ( $currency, $host ) {
 				$latest_version = end( $plugin['versions'] );
 				$download_path  = $latest_version['download'] . '?' . http_build_query( $this->get_environment_parameters() );
 
@@ -140,8 +142,8 @@ class MatomoMarketplaceApi {
 					'description'    => $plugin['description'],
 					'isDownloadable' => $plugin['isDownloadable'],
 					'latestVersion'  => $plugin['latestVersion'],
-					'homeUrl'        => $this->endpoint . rawurlencode( $plugin['name'] ),
-					'downloadUrl'    => $this->endpoint . ltrim( $download_path, '/' ),
+					'homeUrl'        => $host . rawurlencode( $plugin['name'] ),
+					'downloadUrl'    => $host . ltrim( $download_path, '/' ),
 					'addToCartUrl'   => isset( $variationToUse['addToCartUrl'] ) ? ( $variationToUse['addToCartUrl'] . '&wp=1' ) : null,
 				];
 			},


### PR DESCRIPTION
### Description:

Fix issue introduced in previous PR. The $endpoint variable includes the API path (ie, /api/2.0/) and so does the download path in API responses. So they cannot be directly concatenated.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
