### PR TITLE
check for specific tgmpa parameters in $_GET and $_POST

### DIFF
--- a/classes/MatomoMarketplaceAdmin.php
+++ b/classes/MatomoMarketplaceAdmin.php
@@ -170,15 +170,23 @@ class MatomoMarketplaceAdmin {
 
 	private function is_tgmpa_action()
 	{
-		if (!empty($_POST)
-		    || isset($_GET['tgmpa-install'])
-		    || isset($_GET['tgmpa-update'])
-		    || isset($_GET['plugin_status'])
-		    || isset($_GET['tgmpa-nonce'])
-		    || isset($_GET['plugin'])
-		    || isset($_GET['_wpnonce'])
-		    || isset($_GET['nonce'])) {
-			return true;
+		$tgmpa_params = [
+			'tgmpa-install',
+			'tgmpa-update',
+			'plugin_status',
+			'tgmpa-nonce',
+			'plugin',
+			'_wpnonce',
+			'nonce',
+		];
+
+		foreach ( $tgmpa_params as $param ) {
+			if (
+				isset( $_GET[ $param ] )
+				|| isset( $_POST[ $param ] )
+			) {
+				return true;
+			}
 		}
 
 		return false;


### PR DESCRIPTION
### Description:

Problem: overview and license management tabs cannot be displayed. Clicking on either one displays the install plugins tab.

Newest version of wordpress (or possibly a plugin) can add a "referred" post parameter to normal backoffice page requests, so the tgmpa action check fails. Instead of checking for any POST parameters, we now look for specific TGMPA related parameters.

### Review

* [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
* [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behavior of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
* [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
* [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
* [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
* [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
* [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
* [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
* [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
* [ ] [Documentation added if needed](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
* [ ] Existing documentation updated if needed
