### PR TITLE
decorate goal urls for ab tests if functionality exists in mwp

### DIFF
--- a/classes/views/marketplace.php
+++ b/classes/views/marketplace.php
@@ -61,21 +61,27 @@ if ( ! defined( 'ABSPATH' ) ) {
         $apiPlugins = $api->get_available_plugins();
 
         if (!empty($apiPlugins)) {
+			if ( ! function_exists( 'matomo_decorate_goal_url' ) ) {
+				function matomo_decorate_goal_url( $url ) {
+					return $url;
+				}
+			}
+
             foreach ($apiPlugins as $plugin) {
                 $plugins[] = array(
                     'name'               => $plugin['displayName'], // The plugin name.
                     'owner'              => $plugin['owner'],
                     'slug'               => $plugin['name'], // The plugin slug (typically the folder name).
                     'description'        => $plugin['description'], // The plugin slug (typically the folder name).
-                    'source'             => $plugin['downloadUrl'], // The plugin source.
+                    'source'             => matomo_decorate_goal_url( $plugin['downloadUrl'] ), // The plugin source.
                     'required'           => false, // If false, the plugin is only 'recommended' instead of required.
                     'version'            => $plugin['latestVersion'], // E.g. 1.0.0. If set, the active plugin must be this version or higher. If the plugin version is higher than the plugin version installed, the user will be notified to update the plugin.
                     'force_activation'   => false, // If true, plugin is activated upon theme activation and cannot be deactivated until theme switch.
                     'force_deactivation' => false, // If true, plugin is deactivated upon theme switch, useful for theme-specific plugins.
-                    'external_url'       => !empty($plugin['homeUrl']) ? $plugin['homeUrl'] : '', // If set, overrides default API URL and points to an external URL.
+                    'external_url'       => !empty($plugin['homeUrl']) ? matomo_decorate_goal_url( $plugin['homeUrl'] ) : '', // If set, overrides default API URL and points to an external URL.
                     'is_callable'        => '', // If set, this callable will be be checked for availability to determine if a plugin is active.
 					'is_downloadable'    => $plugin['isDownloadable'],
-					'add_to_cart_url'    => $plugin['addToCartUrl'],
+					'add_to_cart_url'    => matomo_decorate_goal_url( $plugin['addToCartUrl'] ),
                 );
             }
         }

--- a/matomo-marketplace-for-wordpress.php
+++ b/matomo-marketplace-for-wordpress.php
@@ -81,6 +81,10 @@ add_action('init', function () {
 	}
 });
 
+add_filter( 'puc_request_info_result-matomo-marketplace-for-wordpress', function ( $plugin_info ) {
+	$plugin_info->download_url = $plugin_info->download_url . '?update=1';
+} );
+
 include 'classes/MatomoMarketplaceAdmin.php';
 include 'classes/MatomoMarketplaceApi.php';
 include 'classes/MatomoMarketplaceTgmpa.php';


### PR DESCRIPTION
### Description

Refs https://github.com/matomo-org/matomo-for-wordpress/pull/1377

TODO

### Checklist

- [✔/✖/NA] I have understood, reviewed, and tested all AI outputs before use
- [✔/✖/NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
