### PR TITLE
in install plugins tab, filter out plugins whose requirements are not met by the current system

### DIFF
--- a/classes/MatomoMarketplaceApi.php
+++ b/classes/MatomoMarketplaceApi.php
@@ -21,8 +21,8 @@ class MatomoMarketplaceApi {
 
 	public function is_valid_api_key( $license_key ) {
 		$looks_valid_format = ctype_alnum( $license_key )
-							  && strlen( $license_key ) >= 40
-							  && strlen( $license_key ) <= 80;
+			&& strlen( $license_key ) >= 40
+			&& strlen( $license_key ) <= 80;
 		if ( ! $looks_valid_format ) {
 			return false;
 		}
@@ -133,6 +133,20 @@ class MatomoMarketplaceApi {
 			}
 		);
 
+		$result = array_map(
+			function ( $plugin ) {
+				return $this->remove_incompatible_versions( $plugin );
+			},
+			$result
+		);
+
+		$result = array_filter(
+			$result,
+			function ( $plugin ) {
+				return ! empty( $plugin['versions'] );
+			}
+		);
+
 		$currency = $this->get_currency_based_on_timezone();
 
 		$host = 'https://' . parse_url( $this->endpoint, PHP_URL_HOST ) . '/';
@@ -229,5 +243,57 @@ class MatomoMarketplaceApi {
 			}
 		}
 		return null;
+	}
+
+	private function remove_incompatible_versions( $plugin ) {
+		foreach ( $plugin['versions'] as $index => $version ) {
+			if ( empty( $version['requires'] ) ) {
+				continue;
+			}
+
+			foreach ( $version['requires'] as $require => $require_version ) {
+				if (
+					$require === 'php'
+					&& $this->matches_version_requirement( $require_version, PHP_MAJOR_VERSION . '.' . PHP_MINOR_VERSION . '.' . PHP_RELEASE_VERSION )
+				) {
+					continue;
+				}
+
+				if (
+					$require === 'matomo'
+					&& class_exists( \Piwik\Version::class )
+					&& $this->matches_version_requirement( $require_version, \Piwik\Version::VERSION )
+				) {
+					continue;
+				}
+
+				// doesn't match
+				unset( $plugin['versions'][ $index ] );
+				break;
+			}
+		}
+
+		return $plugin;
+	}
+
+	private function matches_version_requirement( $require_version, $version ) {
+		$version_match_operators = [ '<=', '>=', '==', '!=', '<', '>' ];
+		$version_match_regex     = array_map( 'preg_quote', $version_match_operators );
+		$version_match_regex     = '/^(' . implode( '|', $version_match_regex ) . ')(.*)/';
+
+		$parts = explode( ',', $require_version );
+		foreach ( $parts as $part ) {
+			if ( ! preg_match( $version_match_regex, $part, $matches ) ) {
+				continue;
+			}
+
+			$operator        = $matches[1];
+			$version_operand = $matches[2];
+
+			if ( ! version_compare( $version, $version_operand, $operator ) ) {
+				return false;
+			}
+		}
+		return true;
 	}
 }


### PR DESCRIPTION
### Description

As title. Will avoid showing plugins that, for example, require PHP 8.1 when the Matomo for WordPress instance is using PHP 7.4.

### Checklist

- [✔/✖/NA] I have understood, reviewed, and tested all AI outputs before use
- [✔/✖/NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
