### PR TITLE
overview/welcome page redesign related changes

### DIFF
--- a/classes/MatomoMarketplaceAdmin.php
+++ b/classes/MatomoMarketplaceAdmin.php
@@ -265,14 +265,6 @@ class MatomoMarketplaceAdmin {
 			$valid_tabs[] = 'subscriptions';
 		}
 
-		$matomoMarketplaceWpMatomo = null;
-		if (class_exists('\WpMatomo\Admin\Marketplace')
-		    && current_user_can('view_matomo')) {
-			$matomoMarketplaceWpMatomo = new \WpMatomo\Admin\Marketplace( \WpMatomo::$settings );
-			$active_tab = 'marketplace'; // default active tab changes to marketplace...
-			$valid_tabs[] = 'marketplace';
-		}
-
 		if ( isset( $_GET['tab'] )
 		     && in_array( $_GET['tab'], $valid_tabs, true ) ) {
 			$active_tab = $_GET['tab'];

--- a/classes/views/marketplace.php
+++ b/classes/views/marketplace.php
@@ -24,12 +24,12 @@ if ( ! defined( 'ABSPATH' ) ) {
         <?php if (in_array('marketplace', $valid_tabs, true)) { ?>
             <a href="?page=matomo-marketplace&tab=marketplace"
                class="nav-tab <?php echo ($active_tab === 'marketplace') ? 'nav-tab-active' : ''; ?>"
-            ><?php esc_html_e( 'Overview', 'matomo-marketplace-for-wordpress' ); ?></a>
+            ><?php esc_html_e( 'Welcome', 'matomo-marketplace-for-wordpress' ); ?></a>
         <?php }?>
 		<?php if (in_array('install', $valid_tabs, true)) { ?>
 		    <a href="?page=matomo-marketplace&tab=install"
                class="nav-tab <?php echo ( $active_tab === 'install' ) ? 'nav-tab-active' : ''; ?>"
-		    ><?php esc_html_e( 'Install Plugins', 'matomo-marketplace-for-wordpress' ); ?></a>
+		    ><?php esc_html_e( 'Marketplace', 'matomo-marketplace-for-wordpress' ); ?></a>
 		<?php }?>
 		<?php if ( in_array('subscriptions', $valid_tabs, true ) ) { ?>
 			<a href="?page=matomo-marketplace&tab=subscriptions"
@@ -37,9 +37,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 		<?php } ?>
 	</h2>
 
-	<?php if ( 'marketplace' === $active_tab ) {
-		$matomoMarketplaceWpMatomo->show();
-	} elseif ( ! empty( $matomo_error ) ) {
+	<?php if ( ! empty( $matomo_error ) ) {
 		?>
 		<p><?php esc_html_e( 'Failed to connect to marketplace API', 'matomo-marketplace-for-wordpress' ); ?>: <?php echo esc_html( $matomo_error ); ?></p>
 		<p><?php esc_html_e( 'Please try reloading the page.', 'matomo-marketplace-for-wordpress' ); ?></p>


### PR DESCRIPTION
### Description

Refs MWP-1006

Changes:
* Change tab name from Install Plugins to Marketplace.
* No longer display overview/welcome tab when the marketplace plugin is active.

### Checklist

- [✔/✖/NA] I have understood, reviewed, and tested all AI outputs before use
- [✔/✖/NA] All AI instructions respect security, IP, and privacy rules

### Review

- [ ] [Functional review done](https://developer.matomo.org/guides/pull-request-reviews#functional-review-done)
- [ ] [Potential edge cases thought about](https://developer.matomo.org/guides/pull-request-reviews#potential-edge-cases-thought-about) (behaviour of the code with strange input, with strange internal state or possible interactions with other Matomo subsystems)
- [ ] [Usability review done](https://developer.matomo.org/guides/pull-request-reviews#usability-review-done) (is anything maybe unclear or think about anything that would cause people to reach out to support)
- [ ] [Security review done](https://developer.matomo.org/guides/security-in-piwik#checklist)
- [ ] [Wording review done](https://developer.matomo.org/guides/pull-request-reviews#translations-wording-review-done)
- [ ] [Code review done](https://developer.matomo.org/guides/pull-request-reviews#code-review-done)
- [ ] [Tests were added if useful/possible](https://developer.matomo.org/guides/pull-request-reviews#tests-were-added-if-usefulpossible)
- [ ] [Reviewed for breaking changes](https://developer.matomo.org/guides/pull-request-reviews#reviewed-for-breaking-changes)
- [ ] [Developer changelog updated if needed](https://developer.matomo.org/guides/pull-request-reviews#developer-changelog-updated-if-needed)
- [ ] [New documentation added or existing documentation updated](https://developer.matomo.org/guides/pull-request-reviews#documentation-added-if-needed)
